### PR TITLE
Fixed conversion of boolean to Python type

### DIFF
--- a/src2/franz/openrdf/model/literal.py
+++ b/src2/franz/openrdf/model/literal.py
@@ -144,7 +144,7 @@ class Literal(Value):
     
     def booleanValue(self):
         """Convert to bool"""
-        return bool(self._label.capitalize())
+        return self._label == 'true'
     
     def dateValue(self):
         """Convert to date"""

--- a/src2/franz/openrdf/tests/tests.py
+++ b/src2/franz/openrdf/tests/tests.py
@@ -1741,6 +1741,7 @@ def test_roundtrips():
     conn = connect()
     now = datetime.datetime.now()
     conn.addTriple('<http:object>', '<http:bool>', True)
+    conn.addTriple('<http:object>', '<http:bool2>', False)
     conn.addTriple('<http:object>', '<http:str>', 'Me')
     conn.addTriple('<http:object>', '<http:int>', 1234)
     conn.addTriple('<http:object>', '<http:long>', 1234L)
@@ -1765,6 +1766,7 @@ def test_roundtrips():
         assert obj == value or abs(obj.microsecond - value.microsecond) < 300
 
     checkit("bool", bool, True)
+    checkit("bool2", bool, False)
     checkit("str", basestring, 'Me')
     checkit("int", int, 1234)
     checkit("long", long, 1234L)


### PR DESCRIPTION
bool() converts any non-empty string to True,
so we need to explicitly check the string content.

Backporting the patch to earlier versions should be considered.
