### PR TITLE
Correction of getContext in place of getObject

### DIFF
--- a/src/franz/openrdf/repository/repositoryconnection.py
+++ b/src/franz/openrdf/repository/repositoryconnection.py
@@ -536,7 +536,7 @@ class RepositoryConnection(object):
         """
         Removes the supplied statement(s) from the specified contexts in the repository.
         """
-        self.removeTriples(statement.getSubject(), statement.getPredicate(), statement.getContext(), contexts=contexts)
+        self.removeTriples(statement.getSubject(), statement.getPredicate(), statement.getObject(), contexts=contexts)
 
     def clear(self, contexts=ALL_CONTEXTS):
         """


### PR DESCRIPTION
In removeStatement, where the subject, predicate and object of the statement are passed to removeTriples, it seems that by mistake a context  is passed instead of an object