### PR TITLE
Swap deprecated urllib3 Retry arg 'method_whitelist' for 'allowed_methods'

### DIFF
--- a/src/franz/miniclient/backends/requests.py
+++ b/src/franz/miniclient/backends/requests.py
@@ -36,7 +36,7 @@ BUFFER_SIZE = 4096
 retries = Retry(backoff_factor=0.1,
                 connect=10,   # 10 retries for connection-level errors
                 status_forcelist=(),  # Retry only on connection errors
-                method_whitelist=False)  # Retry on all methods, even POST and PUT
+                allowed_methods=None)  # Retry on all methods, even POST and PUT
 
 # We'll want to know if something contains unicode
 if sys.version_info >= (3, 0):


### PR DESCRIPTION
As of urllib 2.0.0 (released 2023-04-26), the `method_whitelist` argument for Retry (which has been deprecated for a while) was removed in favor of `allowed_methods`.

This PR simply swaps the old argument for the new one. The behavior should be unchanged. Closes #22.

More info on the `allowed_methods` argument can be found [here](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry).